### PR TITLE
fix: get_node_mappings export

### DIFF
--- a/easy_nodes/__init__.py
+++ b/easy_nodes/__init__.py
@@ -24,6 +24,7 @@ from easy_nodes.easy_nodes import (  # noqa: F401
     register_type,
     show_image,
     show_text,
+    get_node_mappings
 )
 
 # For backwards compatibility with the original comfy_annotations module.


### PR DESCRIPTION
This library works very well and makes my code beautiful, but I realized from the documentation that there is a `get_node_mappings` that is not exported, which makes it unusually cumbersome in some of my environments